### PR TITLE
Rename print_oldest_excercise to print_oldest_exercise

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ fig.savefig("build/Dumbbell_Curl_Pareto_and_Targets.png")
 Generate views:
 ```
 from kaiserlift import (
-    print_oldest_excercise,
+    print_oldest_exercise,
     gen_html_viewer,
 )
 
 # Console print out with optional args
-output_lines = print_oldest_excercise(df, n_cat=2, n_exercises_per_cat=2, n_target_sets_per_exercises=2)
+output_lines = print_oldest_exercise(df, n_cat=2, n_exercises_per_cat=2, n_target_sets_per_exercises=2)
 with open("your_workout_summary.txt", "w") as f:
     f.writelines(output_lines)
 

--- a/kaiserlift/__init__.py
+++ b/kaiserlift/__init__.py
@@ -1,7 +1,7 @@
 from .viewers import (
     get_closest_exercise,
     plot_df,
-    print_oldest_excercise,
+    print_oldest_exercise,
     gen_html_viewer,
 )
 
@@ -24,7 +24,7 @@ __all__ = [
     "get_closest_exercise",
     "plot_df",
     "assert_frame_equal",
-    "print_oldest_excercise",
+    "print_oldest_exercise",
     "import_fitnotes_csv",
     "gen_html_viewer",
 ]

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -97,7 +97,7 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
     return fig
 
 
-def print_oldest_excercise(
+def print_oldest_exercise(
     df, n_cat=2, n_exercises_per_cat=2, n_target_sets_per_exercises=2
 ) -> None:
     df_records = highest_weight_per_rep(df)

--- a/tests/example_use/main.py
+++ b/tests/example_use/main.py
@@ -2,7 +2,7 @@ from kaiserlift import (
     df_next_pareto,
     highest_weight_per_rep,
     plot_df,
-    print_oldest_excercise,
+    print_oldest_exercise,
     import_fitnotes_csv,
     gen_html_viewer,
 )
@@ -30,7 +30,7 @@ fig = plot_df(df, df_records, df_targets, Exercise="Curl Pulldown Bicep")
 fig.savefig("build/Curl Pulldown Bicep Pareto and Targets.png")
 
 # Console print out with optional args
-output_lines = print_oldest_excercise(
+output_lines = print_oldest_exercise(
     df, n_cat=2, n_exercises_per_cat=2, n_target_sets_per_exercises=2
 )
 with open("build/your_workout_summary.txt", "w") as f:


### PR DESCRIPTION
## Summary
- Rename `print_oldest_excercise` to `print_oldest_exercise`
- Update imports, `__all__`, and usage examples
- Adjust README and example script to reference new function name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68978583e70483338e44881c20510723