### PR TITLE
Display selected exercise plots in HTML view

### DIFF
--- a/tests/test_viewers.py
+++ b/tests/test_viewers.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import matplotlib
+
+matplotlib.use("Agg")
+
+from kaiserlift.viewers import gen_html_viewer, _sanitize_for_id
+
+
+def test_gen_html_viewer_sanitizes_ids():
+    df = pd.DataFrame(
+        {
+            "Date": pd.to_datetime(["2024-01-01", "2024-01-01"]),
+            "Exercise": ["Dumbbell Curl", "Barbell Squat"],
+            "Category": ["Biceps", "Legs"],
+            "Weight": [30, 100],
+            "Reps": [10, 5],
+        }
+    )
+
+    html = gen_html_viewer(df)
+
+    for ex in df["Exercise"].unique():
+        sanitized = _sanitize_for_id(ex)
+        assert f'id="fig-{sanitized}"' in html


### PR DESCRIPTION
## Summary
- sanitize exercise names for safe HTML ids and show corresponding plot when dropdown changes
- add regression test for HTML viewer id generation

## Testing
- `pre-commit run --files kaiserlift/viewers.py tests/test_viewers.py`
- `pytest`

Fixes #2

------
https://chatgpt.com/codex/tasks/task_e_689783b279248333b2e3d75996e01f4c