### PR TITLE
Add CI example HTML generator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,30 @@ jobs:
       - name: Run tests using installed package
         run: |
           pytest tests
+
+  generate-example-html:
+    name: Generate example HTML
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install package
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+
+      - name: Generate example HTML
+        run: python tests/example_use/generate_example_html.py
+
+      - name: Upload HTML artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-html
+          path: tests/example_use/build/example.html

--- a/README.md
+++ b/README.md
@@ -111,3 +111,16 @@ with open("your_interactive_table.html", "w", encoding="utf-8") as f:
 from IPython.display import display, HTML
 display(HTML(full_html))
 ```
+
+### Example HTML generation in CI
+
+An example dataset and helper script live in `tests/example_use`. You can
+generate the interactive HTML table locally with:
+
+```
+python tests/example_use/generate_example_html.py
+```
+
+The "Generate example HTML" job in the CI workflow runs the same script and
+publishes the resulting `example.html` file as a build artifact, allowing review
+of the generated page without executing code locally.

--- a/tests/example_use/generate_example_html.py
+++ b/tests/example_use/generate_example_html.py
@@ -1,0 +1,20 @@
+import glob
+from pathlib import Path
+
+from kaiserlift import import_fitnotes_csv, gen_html_viewer
+
+
+def main() -> None:
+    """Generate an example HTML viewer from bundled sample data."""
+    here = Path(__file__).parent
+    csv_files = glob.glob(str(here / "FitNotes_Export_*.csv"))
+    df = import_fitnotes_csv(csv_files)
+    html = gen_html_viewer(df)
+    out_dir = here / "build"
+    out_dir.mkdir(exist_ok=True)
+    out_file = out_dir / "example.html"
+    out_file.write_text(html, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from kaiserlift import gen_html_viewer, import_fitnotes_csv
+
+
+def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
+    csv_file = (
+        Path(__file__).parent
+        / "example_use"
+        / "FitNotes_Export_2025_05_21_08_39_11.csv"
+    )
+    df = import_fitnotes_csv([str(csv_file)])
+    html = gen_html_viewer(df)
+    out_file = tmp_path / "out.html"
+    out_file.write_text(html, encoding="utf-8")
+    assert out_file.exists()
+    assert "<table" in html


### PR DESCRIPTION
## Summary
- add script and test for generating example HTML from sample FitNotes data
- document and wire up CI job that produces HTML artifact for PRs

## Testing
- `pre-commit run --files tests/example_use/generate_example_html.py tests/test_gen_html.py README.md .github/workflows/main.yml`
- `pytest`
- `python tests/example_use/generate_example_html.py`

------
https://chatgpt.com/codex/tasks/task_e_689904604cf883339ad0433994f95448