### PR TITLE
fix: allow publish workflow to push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,12 @@ jobs:
   publish:
     name: Build and Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v6
 


### PR DESCRIPTION
## Summary
- allow publish workflow to push back the bumped version
- update publish workflow to use checkout v4

## Testing
- `uvx pre-commit run --files .github/workflows/publish.yml`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899271cb27c8333844ef144bda766f4