### PR TITLE
Add browser CSV upload page for viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ from IPython.display import display, HTML
 display(HTML(full_html))
 ```
 
+### Browser upload page
+
+A minimal HTML page lives at `static/upload.html`. It lets you upload a CSV and
+posts the file to `/viewer`, replacing the `#viewer` div with the returned
+HTML. The page is self-contained and can be embedded in other sites via an
+`<iframe>`.
+
 ### Example HTML generation in CI
 
 An example dataset and helper script live in `tests/example_use`. You can

--- a/static/upload.html
+++ b/static/upload.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Kaiserlift Upload</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      font-size: 34px;
+      padding: 28px;
+    }
+    input[type="file"] {
+      font-size: 34px;
+      margin-bottom: 20px;
+    }
+    #viewer {
+      margin-top: 20px;
+    }
+  </style>
+</head>
+<body>
+  <input type="file" id="file-input" accept=".csv" />
+  <div id="viewer"></div>
+  <script src="upload.js"></script>
+</body>
+</html>

--- a/static/upload.js
+++ b/static/upload.js
@@ -1,0 +1,26 @@
+(() => {
+  const input = document.getElementById('file-input');
+  const viewer = document.getElementById('viewer');
+
+  input.addEventListener('change', async () => {
+    const file = input.files[0];
+    if (!file) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+
+    try {
+      const response = await fetch('/viewer', {
+        method: 'POST',
+        body: formData,
+        credentials: 'include',
+      });
+      const html = await response.text();
+      viewer.innerHTML = html;
+    } catch (err) {
+      viewer.innerHTML = '<p>Upload failed.</p>';
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add `static/upload.html` with file input and viewer container
- add `static/upload.js` to POST a CSV to `/viewer` and render the response HTML
- document upload page in README

## Testing
- `pre-commit run --files README.md static/upload.html static/upload.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689930d378408333afe81b35b6b13957