### PR TITLE
feat: enable csv upload in HTML viewer

### DIFF
--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -15,3 +15,4 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     out_file.write_text(html, encoding="utf-8")
     assert out_file.exists()
     assert "<table" in html
+    assert "id='csvUpload'" in html


### PR DESCRIPTION
## Summary
- allow users to upload a CSV into generated workout viewer
- parse CSV client-side, recompute 1RM and target sets, and update table
- test ensures HTML output includes upload element

## Testing
- `pre-commit run --files kaiserlift/viewers.py tests/test_gen_html.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995514483c8333a0830d3ff55ac41a