### PR TITLE
feat: add CSV upload to HTML viewer

### DIFF
--- a/kaiserlift/js/processors.js
+++ b/kaiserlift/js/processors.js
@@ -1,0 +1,63 @@
+function calculate1RM(weight, reps) {
+    weight = parseFloat(weight);
+    reps = parseInt(reps);
+    if (!weight || !reps || reps <= 0 || weight < 0) {
+        if (weight === 0 && reps > 0) { return 0; }
+        return NaN;
+    }
+    if (reps === 1) { return weight; }
+    return weight * (1 + reps / 30.0);
+}
+
+function highestWeightPerRep(data) {
+    const groups = {};
+    data.forEach(row => {
+        const ex = row.Exercise;
+        if (!groups[ex]) { groups[ex] = []; }
+        groups[ex].push(row);
+    });
+    const result = [];
+    Object.values(groups).forEach(rows => {
+        const byRep = {};
+        rows.forEach(r => {
+            const reps = parseInt(r.Reps);
+            const weight = parseFloat(r.Weight);
+            if (!byRep[reps] || weight > byRep[reps].Weight) {
+                byRep[reps] = { ...r, Reps: reps, Weight: weight };
+            }
+        });
+        const candidates = Object.values(byRep);
+        candidates.forEach(c => {
+            const superseded = candidates.some(o => o.Reps > c.Reps && o.Weight >= c.Weight);
+            if (!superseded) { result.push(c); }
+        });
+    });
+    return result;
+}
+
+function dfNextPareto(records) {
+    const groups = {};
+    records.forEach(r => {
+        const ex = r.Exercise;
+        if (!groups[ex]) { groups[ex] = []; }
+        groups[ex].push(r);
+    });
+    const rows = [];
+    Object.entries(groups).forEach(([ex, arr]) => {
+        arr.sort((a, b) => a.Reps - b.Reps);
+        const ws = arr.map(r => r.Weight);
+        const rs = arr.map(r => r.Reps);
+        rows.push({ Exercise: ex, Weight: ws[0] + 5, Reps: 1 });
+        for (let i = 0; i < rs.length - 1; i++) {
+            if (rs[i + 1] > rs[i] + 1) {
+                const nr = rs[i] + 1;
+                const c1 = ws[i];
+                const c2 = ws[i + 1] + 5;
+                rows.push({ Exercise: ex, Weight: Math.min(c1, c2), Reps: nr });
+            }
+        }
+        rows.push({ Exercise: ex, Weight: ws[ws.length - 1], Reps: rs[rs.length - 1] + 1 });
+    });
+    rows.forEach(r => { r["1RM"] = calculate1RM(r.Weight, r.Reps); });
+    return rows;
+}

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -268,7 +268,7 @@ def gen_html_viewer(df):
             table.column(0).search(val ? '^' + val + '$' : '', true, false).draw();
 
             $('.exercise-figure').hide();
-            var figId = this.selectedOptions[0].dataset.fig;
+            var figId = $(this).find(':selected').data('fig');
             if (figId) {
                 $('#fig-' + figId).show();
             }

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -219,10 +219,6 @@ def gen_html_viewer(df):
     <script src=\"https://code.jquery.com/jquery-3.5.1.js\"></script>
     <script src=\"https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js\"></script>
 
-    <!-- Select2 for searchable dropdown -->
-    <link href=\"https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css\" rel=\"stylesheet\" />
-    <script src=\"https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js\"></script>
-
     <!-- Custom Styling for Mobile -->
     <style>
     body {
@@ -267,18 +263,12 @@ def gen_html_viewer(df):
             responsive: true
         });
 
-        // Initialize Select2 for searchable dropdown
-        $('#exerciseDropdown').select2({
-            placeholder: "Filter by Exercise",
-            allowClear: true
-        });
-
         $('#exerciseDropdown').on('change', function() {
             var val = $.fn.dataTable.util.escapeRegex($(this).val());
             table.column(0).search(val ? '^' + val + '$' : '', true, false).draw();
 
             $('.exercise-figure').hide();
-            var figId = $(this).find('option:selected').data('fig');
+            var figId = this.selectedOptions[0].dataset.fig;
             if (figId) {
                 $('#fig-' + figId).show();
             }

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -17,4 +17,3 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert "<table" in html
     # ensure at least one exercise figure is present
     assert 'class="exercise-figure"' in html
-    assert 'id="csvUpload"' in html

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -17,3 +17,5 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert "<table" in html
     # ensure at least one exercise figure is present
     assert 'class="exercise-figure"' in html
+    # each dropdown option links to a figure via data attribute
+    assert 'data-fig="' in html

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -17,3 +17,4 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert "<table" in html
     # ensure at least one exercise figure is present
     assert 'class="exercise-figure"' in html
+    assert 'id="csvUpload"' in html


### PR DESCRIPTION
## Summary
- allow uploading a CSV in the generated HTML
- recalculate PR targets in-browser and update the table
- test that the HTML includes the CSV upload control

## Testing
- `pre-commit run --files kaiserlift/viewers.py tests/test_gen_html.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995e52023c83338b73e57aefcbef60