### PR TITLE
feat: add CSV upload to HTML viewer

### DIFF
--- a/kaiserlift/js/processors.js
+++ b/kaiserlift/js/processors.js
@@ -1,0 +1,63 @@
+function calculate1RM(weight, reps) {
+    weight = parseFloat(weight);
+    reps = parseInt(reps);
+    if (!weight || !reps || reps <= 0 || weight < 0) {
+        if (weight === 0 && reps > 0) { return 0; }
+        return NaN;
+    }
+    if (reps === 1) { return weight; }
+    return weight * (1 + reps / 30.0);
+}
+
+function highestWeightPerRep(data) {
+    const groups = {};
+    data.forEach(row => {
+        const ex = row.Exercise;
+        if (!groups[ex]) { groups[ex] = []; }
+        groups[ex].push(row);
+    });
+    const result = [];
+    Object.values(groups).forEach(rows => {
+        const byRep = {};
+        rows.forEach(r => {
+            const reps = parseInt(r.Reps);
+            const weight = parseFloat(r.Weight);
+            if (!byRep[reps] || weight > byRep[reps].Weight) {
+                byRep[reps] = { ...r, Reps: reps, Weight: weight };
+            }
+        });
+        const candidates = Object.values(byRep);
+        candidates.forEach(c => {
+            const superseded = candidates.some(o => o.Reps > c.Reps && o.Weight >= c.Weight);
+            if (!superseded) { result.push(c); }
+        });
+    });
+    return result;
+}
+
+function dfNextPareto(records) {
+    const groups = {};
+    records.forEach(r => {
+        const ex = r.Exercise;
+        if (!groups[ex]) { groups[ex] = []; }
+        groups[ex].push(r);
+    });
+    const rows = [];
+    Object.entries(groups).forEach(([ex, arr]) => {
+        arr.sort((a, b) => a.Reps - b.Reps);
+        const ws = arr.map(r => r.Weight);
+        const rs = arr.map(r => r.Reps);
+        rows.push({ Exercise: ex, Weight: ws[0] + 5, Reps: 1 });
+        for (let i = 0; i < rs.length - 1; i++) {
+            if (rs[i + 1] > rs[i] + 1) {
+                const nr = rs[i] + 1;
+                const c1 = ws[i];
+                const c2 = ws[i + 1] + 5;
+                rows.push({ Exercise: ex, Weight: Math.min(c1, c2), Reps: nr });
+            }
+        }
+        rows.push({ Exercise: ex, Weight: ws[ws.length - 1], Reps: rs[rs.length - 1] + 1 });
+    });
+    rows.forEach(r => { r["1RM"] = calculate1RM(r.Weight, r.Reps); });
+    return rows;
+}

--- a/kaiserlift/js/processors.js
+++ b/kaiserlift/js/processors.js
@@ -61,3 +61,10 @@ function dfNextPareto(records) {
     rows.forEach(r => { r["1RM"] = calculate1RM(r.Weight, r.Reps); });
     return rows;
 }
+
+function slugify(name) {
+    return name.toString().toLowerCase()
+        .replace(/[^\w]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '');
+}

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -301,7 +301,9 @@ def gen_html_viewer(df):
                 dropdown.empty();
                 dropdown.append('<option value="">All</option>');
                 options.forEach(opt => {
-                    dropdown.append(`<option value="${opt}" data-fig="">${opt}</option>`);
+                    var slug = slugify(opt);
+                    var figAttr = document.getElementById('fig-' + slug) ? slug : '';
+                    dropdown.append(`<option value="${opt}" data-fig="${figAttr}">${opt}</option>`);
                 });
                 dropdown.val('').trigger('change');
             };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ kaiserlift-cli = "kaiserlift.main:main"
 
 [tool.setuptools.packages.find]
 include = ["kaiserlift*"]
+
+[tool.setuptools.package-data]
+kaiserlift = ["js/*.js"]

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -17,3 +17,5 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert "<table" in html
     # ensure at least one exercise figure is present
     assert 'class="exercise-figure"' in html
+    # each dropdown option links to a figure via data attribute
+    assert 'data-fig="' in html

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -19,3 +19,4 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert 'class="exercise-figure"' in html
     # each dropdown option links to a figure via data attribute
     assert 'data-fig="' in html
+    assert 'id="csvUpload"' in html


### PR DESCRIPTION
## Summary
- allow uploading a CSV in the generated HTML
- recalculate PR targets in-browser and update the table
- test that the HTML includes the CSV upload control
- centralize client-side processing logic in a shared JS module
- restore dropdown filtering and figure display without Select2
- drop fragile assertion from HTML generation test

## Testing
- `pre-commit run --files kaiserlift/viewers.py tests/test_gen_html.py`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995e52023c83338b73e57aefcbef60