### PR TITLE
Add CI summary preview for example HTML

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,23 @@ jobs:
       - name: Generate example HTML
         run: uv run python tests/example_use/generate_example_html.py
 
+      - name: Add HTML preview to summary
+        run: |
+          python - <<'PY'
+          import base64, pathlib, os
+
+          html_path = pathlib.Path("tests/example_use/build/example.html")
+          b64 = base64.b64encode(html_path.read_bytes()).decode()
+
+          summary = pathlib.Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a") as fh:
+              fh.write("### Example HTML\n")
+              fh.write(f"[Open example.html](data:text/html;base64,{b64})\n\n")
+              fh.write("<details><summary>HTML source</summary>\n\n```html\n")
+              fh.write(html_path.read_text())
+              fh.write("\n```\n</details>\n")
+          PY
+
       - name: Upload HTML artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -132,4 +132,6 @@ python tests/example_use/generate_example_html.py
 
 The "Generate example HTML" job in the CI workflow runs the same script and
 publishes the resulting `example.html` file as a build artifact, allowing review
-of the generated page without executing code locally.
+of the generated page without executing code locally. For quick inspection,
+the job summary also contains a direct link and the HTML source so the page can
+be viewed without downloading and extracting the artifact.


### PR DESCRIPTION
## Summary
- surface generated example HTML in CI job summary via inline source and data link for quick viewing
- document new preview ability in README

## Testing
- `uvx pre-commit run --all-files`
- `python -m pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689a0df7eae48333aafc83a5ea81e4c0