### PR TITLE
feat: add CSV upload to HTML viewer

### DIFF
--- a/kaiserlift/js/processors.js
+++ b/kaiserlift/js/processors.js
@@ -1,0 +1,70 @@
+function calculate1RM(weight, reps) {
+    weight = parseFloat(weight);
+    reps = parseInt(reps);
+    if (!weight || !reps || reps <= 0 || weight < 0) {
+        if (weight === 0 && reps > 0) { return 0; }
+        return NaN;
+    }
+    if (reps === 1) { return weight; }
+    return weight * (1 + reps / 30.0);
+}
+
+function highestWeightPerRep(data) {
+    const groups = {};
+    data.forEach(row => {
+        const ex = row.Exercise;
+        if (!groups[ex]) { groups[ex] = []; }
+        groups[ex].push(row);
+    });
+    const result = [];
+    Object.values(groups).forEach(rows => {
+        const byRep = {};
+        rows.forEach(r => {
+            const reps = parseInt(r.Reps);
+            const weight = parseFloat(r.Weight);
+            if (!byRep[reps] || weight > byRep[reps].Weight) {
+                byRep[reps] = { ...r, Reps: reps, Weight: weight };
+            }
+        });
+        const candidates = Object.values(byRep);
+        candidates.forEach(c => {
+            const superseded = candidates.some(o => o.Reps > c.Reps && o.Weight >= c.Weight);
+            if (!superseded) { result.push(c); }
+        });
+    });
+    return result;
+}
+
+function dfNextPareto(records) {
+    const groups = {};
+    records.forEach(r => {
+        const ex = r.Exercise;
+        if (!groups[ex]) { groups[ex] = []; }
+        groups[ex].push(r);
+    });
+    const rows = [];
+    Object.entries(groups).forEach(([ex, arr]) => {
+        arr.sort((a, b) => a.Reps - b.Reps);
+        const ws = arr.map(r => r.Weight);
+        const rs = arr.map(r => r.Reps);
+        rows.push({ Exercise: ex, Weight: ws[0] + 5, Reps: 1 });
+        for (let i = 0; i < rs.length - 1; i++) {
+            if (rs[i + 1] > rs[i] + 1) {
+                const nr = rs[i] + 1;
+                const c1 = ws[i];
+                const c2 = ws[i + 1] + 5;
+                rows.push({ Exercise: ex, Weight: Math.min(c1, c2), Reps: nr });
+            }
+        }
+        rows.push({ Exercise: ex, Weight: ws[ws.length - 1], Reps: rs[rs.length - 1] + 1 });
+    });
+    rows.forEach(r => { r["1RM"] = calculate1RM(r.Weight, r.Reps); });
+    return rows;
+}
+
+function slugify(name) {
+    return name.toString().toLowerCase()
+        .replace(/[^\w]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '');
+}

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import base64
 import re
 from io import BytesIO
+from pathlib import Path
 from .df_processers import (
     calculate_1rm,
     highest_weight_per_rep,
@@ -149,6 +150,7 @@ def print_oldest_exercise(
 def gen_html_viewer(df):
     df_records = highest_weight_per_rep(df)
     df_targets = df_next_pareto(df_records)
+    processors_js = (Path(__file__).with_name("js") / "processors.js").read_text()
 
     # Create a dictionary: { exercise_name: base64_image_string }
     figures_html: dict[str, str] = {}
@@ -187,6 +189,9 @@ def gen_html_viewer(df):
 
     # Build dropdown with data attribute linking to figure id
     dropdown_html = """
+    <label for="csvUpload">Upload CSV:</label>
+    <input type="file" id="csvUpload" accept=".csv" />
+    <br><br>
     <label for="exerciseDropdown">Filter by Exercise:</label>
     <select id="exerciseDropdown">
     <option value="">All</option>
@@ -205,17 +210,12 @@ def gen_html_viewer(df):
         classes="display compact cell-border", table_id="exerciseTable", index=False
     )
 
-    # JS and CSS for DataTables + filtering
-    # JS, CSS, and styling improvements
-    js_and_css = """
+    # CSS and vendor JS go at the top
+    head_html = """
     <!-- DataTables -->
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css"/>
-    <script src="https://code.jquery.com/jquery-3.5.1.js"></script>
-    <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
-
-    <!-- Select2 for searchable dropdown -->
-    <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
-    <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <link rel=\"stylesheet\" href=\"https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css\"/>
+    <script src=\"https://code.jquery.com/jquery-3.5.1.js\"></script>
+    <script src=\"https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js\"></script>
 
     <!-- Custom Styling for Mobile -->
     <style>
@@ -249,38 +249,74 @@ def gen_html_viewer(df):
         }
     }
     </style>
+    """
 
+    # Script loaded at the end so DOM elements exist
+    script_html = (
+        """
     <script>
+    """
+        + processors_js
+        + """
+
     $(document).ready(function() {
         // Initialize DataTable
         var table = $('#exerciseTable').DataTable({
             responsive: true
         });
 
-        // Initialize Select2 for searchable dropdown
-        $('#exerciseDropdown').select2({
-            placeholder: "Filter by Exercise",
-            allowClear: true
-        });
-
         $('#exerciseDropdown').on('change', function() {
             var val = $.fn.dataTable.util.escapeRegex($(this).val());
             table.column(0).search(val ? '^' + val + '$' : '', true, false).draw();
 
-            // Hide all figures
             $('.exercise-figure').hide();
-
-            // Show the matching figure
-            var figId = $(this).find('option:selected').data('fig');
+            var figId = $(this).find(':selected').data('fig');
             if (figId) {
                 $('#fig-' + figId).show();
             }
         });
+
+        $('#csvUpload').on('change', function(evt) {
+            var file = evt.target.files[0];
+            if (!file) { return; }
+            var reader = new FileReader();
+            reader.onload = function(e) {
+                var text = e.target.result.trim();
+                var lines = text.split(/\r?\n/);
+                var headers = lines[0].split(',');
+                var data = lines.slice(1).map(line => {
+                    var cols = line.split(',');
+                    var obj = {};
+                    headers.forEach((h, i) => { obj[h.trim()] = cols[i]; });
+                    return obj;
+                });
+                var records = highestWeightPerRep(data);
+                var targets = dfNextPareto(records);
+                table.clear();
+                targets.forEach(r => {
+                    table.row.add([r.Exercise, r.Weight, r.Reps, r["1RM"].toFixed(2)]);
+                });
+                table.draw();
+                $('.exercise-figure').hide();
+                var options = [...new Set(data.map(d => d.Exercise))].sort();
+                var dropdown = $('#exerciseDropdown');
+                dropdown.empty();
+                dropdown.append('<option value="">All</option>');
+                options.forEach(opt => {
+                    var slug = slugify(opt);
+                    var figAttr = document.getElementById('fig-' + slug) ? slug : '';
+                    dropdown.append(`<option value="${opt}" data-fig="${figAttr}">${opt}</option>`);
+                });
+                dropdown.val('').trigger('change');
+            };
+            reader.readAsText(file);
+        });
     });
     </script>
     """
+    )
 
     # Final combo
-    full_html = js_and_css + dropdown_html + table_html + all_figures_html
+    full_html = head_html + dropdown_html + table_html + all_figures_html + script_html
 
     return full_html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ kaiserlift-cli = "kaiserlift.main:main"
 
 [tool.setuptools.packages.find]
 include = ["kaiserlift*"]
+
+[tool.setuptools.package-data]
+kaiserlift = ["js/*.js"]

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -17,3 +17,6 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert "<table" in html
     # ensure at least one exercise figure is present
     assert 'class="exercise-figure"' in html
+    # each dropdown option links to a figure via data attribute
+    assert 'data-fig="' in html
+    assert 'id="csvUpload"' in html


### PR DESCRIPTION
## Summary
- allow uploading a CSV in the generated HTML
- recalculate PR targets in-browser and update the table
- preserve figure links when swapping datasets by slugifying exercise names
- test that the HTML includes the CSV upload control
- centralize client-side processing logic in a shared JS module
- restore dropdown filtering and figure display without Select2
- drop fragile assertion from HTML generation test
- include shared processors.js in package data so the upload handler is available after installation
- ensure CSV upload controls precede scripts so the element is always present

## Testing
- `pre-commit run --files kaiserlift/viewers.py tests/test_gen_html.py kaiserlift/js/processors.js pyproject.toml`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68995e52023c83338b73e57aefcbef60