### PR TITLE
chore: add diagnostic module path print

### DIFF
--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -1,9 +1,12 @@
 from pathlib import Path
+import inspect
 
 from kaiserlift import gen_html_viewer, import_fitnotes_csv
 
 
 def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
+    # Diagnostic to ensure we are testing the local source
+    print("gen_html_viewer module path:", inspect.getfile(gen_html_viewer))
     csv_file = (
         Path(__file__).parent
         / "example_use"


### PR DESCRIPTION
## Summary
- print the module location in gen_html viewer test for easier debugging

## Testing
- `pre-commit run --files tests/test_gen_html.py`
- `PYTHONPATH=. pytest tests/test_gen_html.py::test_gen_html_viewer_creates_html -q -s`


------
https://chatgpt.com/codex/tasks/task_e_689b67ddce5883339e17d6cd0080b85a