### PR TITLE
Use shared pipeline in web app

### DIFF
--- a/kaiserlift/__init__.py
+++ b/kaiserlift/__init__.py
@@ -16,6 +16,8 @@ from .df_processers import (
     process_csv_files,
 )
 
+from .pipeline import pipeline
+
 __all__ = [
     "calculate_1rm",
     "highest_weight_per_rep",
@@ -29,4 +31,5 @@ __all__ = [
     "import_fitnotes_csv",
     "process_csv_files",
     "gen_html_viewer",
+    "pipeline",
 ]

--- a/kaiserlift/pipeline.py
+++ b/kaiserlift/pipeline.py
@@ -1,0 +1,45 @@
+"""High-level data processing pipeline for KaiserLift.
+
+The pipeline centralizes all numeric calculations in Python. Client-side
+JavaScript is limited to user interface updates such as filtering or
+showing figures and does not duplicate these computations.
+"""
+
+from __future__ import annotations
+
+from typing import IO, Iterable
+
+from .df_processers import (
+    df_next_pareto,
+    highest_weight_per_rep,
+    process_csv_files,
+)
+from .viewers import gen_html_viewer
+
+
+def pipeline(files: Iterable[IO]) -> str:
+    """Run the KaiserLift processing pipeline and return HTML.
+
+    Parameters
+    ----------
+    files:
+        Iterable of file paths or file-like objects containing FitNotes CSV data.
+
+    Returns
+    -------
+    str
+        The HTML output produced by :func:`gen_html_viewer`.
+
+    Notes
+    -----
+    All heavy computations happen here on the server. The JavaScript emitted in
+    the HTML focuses solely on updating the UI and performs no calculations.
+    """
+
+    df = process_csv_files(files)
+
+    # Execute full pipeline for side effects and potential validation.
+    records = highest_weight_per_rep(df)
+    _ = df_next_pareto(records)
+
+    return gen_html_viewer(df)

--- a/kaiserlift/webapp.py
+++ b/kaiserlift/webapp.py
@@ -18,7 +18,7 @@ import os
 from fastapi import FastAPI, File, UploadFile
 from fastapi.responses import HTMLResponse
 
-from . import df_next_pareto, gen_html_viewer, highest_weight_per_rep, process_csv_files
+from .pipeline import pipeline
 
 
 app = FastAPI()
@@ -50,16 +50,14 @@ async def index() -> HTMLResponse:
 
 @app.post("/upload", response_class=HTMLResponse)
 async def upload(file: UploadFile = File(...)) -> HTMLResponse:
-    """Process the uploaded CSV and return the rendered HTML snippet."""
+    """Process the uploaded CSV via the core pipeline and return HTML.
 
-    df = process_csv_files([file.file])
+    All numerical computations occur within :func:`pipeline`. Any JavaScript
+    embedded in the resulting HTML is dedicated solely to updating the user
+    interface and performs no calculations.
+    """
 
-    # These calls are executed separately to satisfy the requirement of running
-    # each processing step explicitly.
-    _records = highest_weight_per_rep(df)
-    _targets = df_next_pareto(_records)
-
-    html = gen_html_viewer(df)
+    html = pipeline([file.file])
     return HTMLResponse(html)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import kaiserlift
+
+
+pipeline = getattr(kaiserlift, "pipeline")
+
+
+def test_pipeline_generates_html() -> None:
+    csv_path = Path("tests/example_use/FitNotes_Export_2025_05_21_08_39_11.csv")
+    with csv_path.open("rb") as fh:
+        html = pipeline([fh])
+    assert "<table" in html


### PR DESCRIPTION
## Summary
- Centralize KaiserLift CSV processing in a dedicated `pipeline` module
- Route FastAPI upload endpoint through the new pipeline, with docs noting JS only updates the UI
- Export pipeline at package level and add tests for pipeline integration

## Testing
- `pre-commit run --files kaiserlift/pipeline.py kaiserlift/__init__.py kaiserlift/webapp.py tests/test_pipeline.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d049e27788333bfd24c7b9722231d