### PR TITLE
feat: build client wheel for static serving

### DIFF
--- a/.github/workflows/build-client-wheel.yml
+++ b/.github/workflows/build-client-wheel.yml
@@ -1,0 +1,27 @@
+name: Build client wheel
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Build wheel
+        run: |
+          uv build
+          mkdir -p client
+          cp dist/*.whl client/kaiserlift.whl
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: client-wheel
+          path: client/kaiserlift.whl

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ cython_debug/
 
 # From the actual data source as a test
 *.csv
+
+# Client wheel artifact
+client/*.whl

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,8 @@
+# Client distribution
+
+This directory hosts the built wheel for static serving. The wheel is generated in CI and uploaded as a `client-wheel` artifact, so the binary itself is not checked into the repository.
+
+## Rebuild locally
+1. Install the build backend with `pip install build` or `uv`.
+2. Run `python -m build` (or `uv build`) from the repository root.
+3. Copy `dist/kaiserlift-<VERSION>-py3-none-any.whl` to this directory as `kaiserlift.whl` if you need a local copy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     "numpy",
     "matplotlib",
     "ipython",
+]
+
+[project.optional-dependencies]
+server = [
     "fastapi",
     "uvicorn",
     "python-multipart",


### PR DESCRIPTION
## Summary
- move FastAPI stack to optional `server` extra
- build client wheel in CI and upload as artifact
- ignore committed wheel and document how to rebuild locally

## Testing
- `uvx pre-commit run --files .gitignore client/README.md .github/workflows/build-client-wheel.yml`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1632ba088333b0a7d6e93d69bbe7