### PR TITLE
feat(client): add HTML page for CSV upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *$py.class
 
 *.html
+!client/index.html
 *.txt
 
 # C extensions

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Kaiserlift CSV Upload</title>
+</head>
+<body>
+  <input type="file" id="csvFile" />
+  <button id="uploadButton">Upload</button>
+  <div id="result"></div>
+  <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
+  <script type="module" src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Pyodide-powered CSV upload page
- allow tracking of client/index.html in gitignore

## Testing
- `pre-commit run --files client/index.html .gitignore`
- `pytest` *(fails: ModuleNotFoundError: No module named 'kaiserlift')*


------
https://chatgpt.com/codex/tasks/task_e_689d6665d6f083339a3ade4e17cb5aad