### PR TITLE
Allow HTML viewer to skip asset injection for client usage

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -9,7 +9,7 @@ export async function init(loadPyodide, doc = document) {
       )).loadPyodide;
     const pyodide = await loader();
     await pyodide.loadPackage(["pandas", "numpy", "matplotlib", "micropip"]);
-    const wheelUrl = "client/kaiserlift-0.1.24-py3-none-any.whl";
+    const wheelUrl = "client/kaiserlift-0.1.25-py3-none-any.whl";
     const response = await fetch(wheelUrl);
     if (!response.ok) {
       throw new Error(`Failed to fetch wheel: ${response.status}`);

--- a/kaiserlift/pipeline.py
+++ b/kaiserlift/pipeline.py
@@ -7,6 +7,7 @@ showing figures and does not duplicate these computations.
 
 from __future__ import annotations
 
+import sys
 from typing import IO, Iterable
 
 from .df_processers import (
@@ -17,13 +18,17 @@ from .df_processers import (
 from .viewers import gen_html_viewer
 
 
-def pipeline(files: Iterable[IO]) -> str:
+def pipeline(files: Iterable[IO], *, embed_assets: bool | None = None) -> str:
     """Run the KaiserLift processing pipeline and return HTML.
 
     Parameters
     ----------
     files:
         Iterable of file paths or file-like objects containing FitNotes CSV data.
+    embed_assets:
+        When ``True`` include ``<script>`` and ``<link>`` tags in the returned
+        HTML. If ``None`` (the default), assets are embedded unless the code is
+        executing in a Pyodide environment.
 
     Returns
     -------
@@ -42,4 +47,7 @@ def pipeline(files: Iterable[IO]) -> str:
     records = highest_weight_per_rep(df)
     _ = df_next_pareto(records)
 
-    return gen_html_viewer(df)
+    if embed_assets is None:
+        embed_assets = sys.platform != "emscripten"
+
+    return gen_html_viewer(df, embed_assets=embed_assets)


### PR DESCRIPTION
## Summary
- split HTML generation into `render_table_fragment` and wrapper `gen_html_viewer`
- add `embed_assets` flag to HTML viewer and pipeline
- update client wheel reference

## Testing
- `pre-commit run --files kaiserlift/viewers.py kaiserlift/pipeline.py client/main.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4204ae1c8333bd59b1ed34e2fbfa