### PR TITLE
Initialize DataTables and Select2 after dynamic HTML injection

### DIFF
--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -256,35 +256,6 @@ def gen_html_viewer(df):
         }
     }
     </style>
-
-    <script>
-    $(document).ready(function() {
-        // Initialize DataTable
-        var table = $('#exerciseTable').DataTable({
-            responsive: true
-        });
-
-        // Initialize Select2 for searchable dropdown
-        $('#exerciseDropdown').select2({
-            placeholder: "Filter by Exercise",
-            allowClear: true
-        });
-
-        $('#exerciseDropdown').on('change', function() {
-            var val = $.fn.dataTable.util.escapeRegex($(this).val());
-            table.column(0).search(val ? '^' + val + '$' : '', true, false).draw();
-
-            // Hide all figures
-            $('.exercise-figure').hide();
-
-            // Show the matching figure
-            var figId = $(this).find('option:selected').data('fig');
-            if (figId) {
-                $('#fig-' + figId).show();
-            }
-        });
-    });
-    </script>
     """
 
     # Final combo


### PR DESCRIPTION
## Summary
- introduce `initializeUI` helper to activate DataTables and Select2 on demand
- reinitialize UI after uploads and on initial page load
- remove inline DataTables/Select2 script from `gen_html_viewer` and update client wheel reference

## Testing
- `pre-commit run --files client/main.js kaiserlift/viewers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4205a3c483338f349f8d297bd578