### PR TITLE
Embed assets in webapp pipeline

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -9,7 +9,7 @@ export async function init(loadPyodide, doc = document) {
       )).loadPyodide;
     const pyodide = await loader();
     await pyodide.loadPackage(["pandas", "numpy", "matplotlib", "micropip"]);
-    const wheelUrl = "client/kaiserlift-0.1.24-py3-none-any.whl";
+    const wheelUrl = "client/kaiserlift-0.1.25-py3-none-any.whl";
     const response = await fetch(wheelUrl);
     if (!response.ok) {
       throw new Error(`Failed to fetch wheel: ${response.status}`);

--- a/kaiserlift/pipeline.py
+++ b/kaiserlift/pipeline.py
@@ -7,6 +7,7 @@ showing figures and does not duplicate these computations.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import IO, Iterable
 
 from .df_processers import (
@@ -17,7 +18,7 @@ from .df_processers import (
 from .viewers import gen_html_viewer
 
 
-def pipeline(files: Iterable[IO]) -> str:
+def pipeline(files: Iterable[IO], *, embed_assets: bool = False) -> str:
     """Run the KaiserLift processing pipeline and return HTML.
 
     Parameters
@@ -42,4 +43,15 @@ def pipeline(files: Iterable[IO]) -> str:
     records = highest_weight_per_rep(df)
     _ = df_next_pareto(records)
 
-    return gen_html_viewer(df)
+    html = gen_html_viewer(df)
+    if embed_assets:
+        main_js = Path(__file__).resolve().parent.parent / "client" / "main.js"
+        if main_js.exists():
+            script = main_js.read_text(encoding="utf-8")
+            html = html.replace(
+                '<script type="module" src="main.js"></script>',
+                f'<script type="module">{script}</script>',
+            )
+        html = f"<!DOCTYPE html><html><head></head><body>{html}</body></html>"
+
+    return html

--- a/kaiserlift/webapp.py
+++ b/kaiserlift/webapp.py
@@ -57,7 +57,7 @@ async def upload(file: UploadFile = File(...)) -> HTMLResponse:
     interface and performs no calculations.
     """
 
-    html = pipeline([file.file])
+    html = pipeline([file.file], embed_assets=True)
     return HTMLResponse(html)
 
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -34,4 +34,5 @@ def test_upload_csv() -> None:
         )
 
     assert response.status_code == 200
+    assert "<html" in response.text
     assert "exercise-figure" in response.text


### PR DESCRIPTION
## Summary
- allow `pipeline` to optionally embed client assets and wrap output in a full HTML document
- use `embed_assets=True` in the FastAPI upload endpoint
- update webapp test to reflect new markup

## Testing
- `pre-commit run --files kaiserlift/pipeline.py kaiserlift/webapp.py tests/test_webapp.py client/main.js`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e42077b548333a5fa68aa6bf4bcb9