### PR TITLE
Refactor viewer to support optional asset embedding

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -39,7 +39,7 @@ await micropip.install('${wheelName}')
 import io
 from kaiserlift.pipeline import pipeline
 buffer = io.StringIO(csv_text)
-pipeline([buffer])
+pipeline([buffer], embed_assets=False)
 `);
         result.innerHTML = html;
       } catch (err) {

--- a/kaiserlift/pipeline.py
+++ b/kaiserlift/pipeline.py
@@ -17,13 +17,18 @@ from .df_processers import (
 from .viewers import gen_html_viewer
 
 
-def pipeline(files: Iterable[IO]) -> str:
+def pipeline(files: Iterable[IO], *, embed_assets: bool = True) -> str:
     """Run the KaiserLift processing pipeline and return HTML.
 
     Parameters
     ----------
     files:
-        Iterable of file paths or file-like objects containing FitNotes CSV data.
+        Iterable of file paths or file-like objects containing FitNotes CSV
+        data.
+    embed_assets:
+        If ``True`` (default) the returned HTML includes the required CSS and
+        JavaScript assets. Set to ``False`` when the caller already embeds these
+        assets, such as the in-browser client.
 
     Returns
     -------
@@ -42,4 +47,4 @@ def pipeline(files: Iterable[IO]) -> str:
     records = highest_weight_per_rep(df)
     _ = df_next_pareto(records)
 
-    return gen_html_viewer(df)
+    return gen_html_viewer(df, embed_assets=embed_assets)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,3 +11,12 @@ def test_pipeline_generates_html() -> None:
     with csv_path.open("rb") as fh:
         html = pipeline([fh])
     assert "<table" in html
+
+
+def test_pipeline_fragment_without_assets() -> None:
+    csv_path = Path("tests/example_use/FitNotes_Export_2025_05_21_08_39_11.csv")
+    with csv_path.open("rb") as fh:
+        html = pipeline([fh], embed_assets=False)
+    assert "<table" in html
+    assert "<script" not in html
+    assert "<link" not in html

--- a/tests/test_pyodide_client.py
+++ b/tests/test_pyodide_client.py
@@ -66,7 +66,7 @@ def test_pipeline_via_pyodide(tmp_path: Path) -> None:
                 }}
                 if (code.includes("pipeline([")) {{
                   const csv = pyodide.globals.get('csv_text');
-                  const py = `\\nimport io, sys, json\\nfrom kaiserlift.pipeline import pipeline\\nbuffer = io.StringIO(json.loads(sys.argv[1]))\\nsys.stdout.write(pipeline([buffer]))\\n`;
+                  const py = `\\nimport io, sys, json\\nfrom kaiserlift.pipeline import pipeline\\nbuffer = io.StringIO(json.loads(sys.argv[1]))\\nsys.stdout.write(pipeline([buffer], embed_assets=False))\\n`;
                   const r = spawnSync('{sys.executable}', ['-c', py, JSON.stringify(csv)], {{ encoding: 'utf-8' }});
                   if (r.status !== 0) throw new Error(r.stderr);
                   return r.stdout;


### PR DESCRIPTION
## Summary
- extract `render_table_fragment` to produce HTML without asset tags
- add `embed_assets` flag to `gen_html_viewer` and pipeline
- ensure client uses `embed_assets=False` for fragment-only output

## Testing
- `python -m pre_commit run --files kaiserlift/viewers.py kaiserlift/pipeline.py client/main.js tests/test_pipeline.py tests/test_pyodide_client.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e4f08753c8333bb17cdfd334660b4