### PR TITLE
Ensure FastAPI upload embeds assets

### DIFF
--- a/kaiserlift/webapp.py
+++ b/kaiserlift/webapp.py
@@ -57,7 +57,10 @@ async def upload(file: UploadFile = File(...)) -> HTMLResponse:
     interface and performs no calculations.
     """
 
-    html = pipeline([file.file])
+    # ``pipeline`` no longer embeds required JavaScript and CSS assets by
+    # default.  Explicitly enable ``embed_assets`` so the returned HTML is a
+    # standalone page suitable for direct rendering by the browser.
+    html = pipeline([file.file], embed_assets=True)
     return HTMLResponse(html)
 
 

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -35,3 +35,5 @@ def test_upload_csv() -> None:
 
     assert response.status_code == 200
     assert "exercise-figure" in response.text
+    # ``upload`` should return a standalone HTML page with embedded assets.
+    assert "<script" in response.text


### PR DESCRIPTION
## Summary
- Explicitly enable asset embedding in webapp pipeline call so returned HTML is standalone
- Extend upload test to check that embedded scripts are present

## Testing
- `pre-commit run --files kaiserlift/webapp.py tests/test_webapp.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e8516e17c8333afe5ebe63a0cba79