### PR TITLE
Add Pyodide wheel fetch and viewer tests

### DIFF
--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -26,3 +26,14 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert "<table" in html
     # ensure at least one exercise figure is present
     assert 'class="exercise-figure"' in html
+
+
+def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
+    csv_file = (
+        Path(__file__).parent
+        / "example_use"
+        / "FitNotes_Export_2025_05_21_08_39_11.csv"
+    )
+    df = process_csv_files([str(csv_file)])
+    html = gen_html_viewer(df, embed_assets=False)
+    assert "<script" not in html


### PR DESCRIPTION
## Summary
- check Pyodide client fetches local `client/kaiserlift.whl` and replaces old results when uploading
- verify `gen_html_viewer` omits `<script>` tags when assets aren't embedded

## Testing
- `pre-commit run --files tests/test_pyodide_client.py tests/test_gen_html.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e8be1a5608333b39499cf4c590a2e