### PR TITLE
Refactor viewer HTML structure

### DIFF
--- a/kaiserlift/pipeline.py
+++ b/kaiserlift/pipeline.py
@@ -26,9 +26,11 @@ def pipeline(files: Iterable[IO], *, embed_assets: bool = True) -> str:
         Iterable of file paths or file-like objects containing FitNotes CSV
         data.
     embed_assets:
-        If ``True`` (default) the returned HTML includes the required CSS and
-        JavaScript assets. Set to ``False`` when the caller already embeds these
-        assets, such as the in-browser client.
+        If ``True`` (default) the returned HTML includes the upload controls and
+        required CSS/JavaScript for a standalone page. Set to ``False`` to
+        obtain only the table/dropdown/figure fragment suitable for insertion
+        into an existing ``<div id="result">`` where the surrounding page
+        already provides the necessary assets.
 
     Returns
     -------

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -200,18 +200,11 @@ def render_table_fragment(df) -> str:
     <br><br>
     """
 
-    upload_html = """
-    <input type="file" id="csvFile">
-    <button id="uploadButton">Upload</button>
-    <div id="result"></div>
-    <br><br>
-    """
-
     table_html = df_targets.to_html(
         classes="display compact cell-border", table_id="exerciseTable", index=False
     )
 
-    return dropdown_html + upload_html + table_html + all_figures_html
+    return dropdown_html + table_html + all_figures_html
 
 
 def gen_html_viewer(df, *, embed_assets: bool = True) -> str:
@@ -275,9 +268,14 @@ def gen_html_viewer(df, *, embed_assets: bool = True) -> str:
     </style>
     """
 
+    upload_html = """
+    <input type="file" id="csvFile">
+    <button id="uploadButton">Upload</button>
+    """
+
     scripts = """
     <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
     <script type="module" src="main.js"></script>
     """
 
-    return js_and_css + fragment + scripts
+    return js_and_css + upload_html + f'<div id="result">{fragment}</div>' + scripts

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -26,6 +26,10 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert "<table" in html
     # ensure at least one exercise figure is present
     assert 'class="exercise-figure"' in html
+    # upload controls should be present once and content wrapped in a single result div
+    assert html.count('id="result"') == 1
+    assert 'id="uploadButton"' in html
+    assert 'id="csvFile"' in html
 
 
 def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
@@ -37,3 +41,7 @@ def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
     df = process_csv_files([str(csv_file)])
     html = gen_html_viewer(df, embed_assets=False)
     assert "<script" not in html
+    assert "<link" not in html
+    assert 'id="uploadButton"' not in html
+    assert 'id="csvFile"' not in html
+    assert 'id="result"' not in html

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -11,6 +11,8 @@ def test_pipeline_generates_html() -> None:
     with csv_path.open("rb") as fh:
         html = pipeline([fh])
     assert "<table" in html
+    assert html.count('id="result"') == 1
+    assert 'id="uploadButton"' in html
 
 
 def test_pipeline_fragment_without_assets() -> None:
@@ -20,3 +22,6 @@ def test_pipeline_fragment_without_assets() -> None:
     assert "<table" in html
     assert "<script" not in html
     assert "<link" not in html
+    assert 'id="uploadButton"' not in html
+    assert 'id="csvFile"' not in html
+    assert 'id="result"' not in html

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -37,3 +37,4 @@ def test_upload_csv() -> None:
     assert "exercise-figure" in response.text
     # ``upload`` should return a standalone HTML page with embedded assets.
     assert "<script" in response.text
+    assert response.text.count('id="result"') == 1


### PR DESCRIPTION
## Summary
- simplify `render_table_fragment` to emit only dropdown, table and figures
- wrap viewer output in a single `div#result` when assets are embedded
- document and test fragment-only output from `pipeline(embed_assets=False)`

## Testing
- `pre-commit run --files kaiserlift/viewers.py kaiserlift/pipeline.py tests/test_gen_html.py tests/test_pipeline.py tests/test_webapp.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e99b54d908333b9f94e1f7ee2a7f2