### PR TITLE
feat: inject package version into client

### DIFF
--- a/.github/workflows/build-client-wheel.yml
+++ b/.github/workflows/build-client-wheel.yml
@@ -14,6 +14,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@v6
 
+      - name: Inject version into client
+        run: uv run --no-project python scripts/inject_version.py
+
       - name: Build wheel
         run: |
           uv build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
           uv venv
           uv pip install -e . pytest
 
+      - name: Inject version into client
+        run: uv run --no-project python scripts/inject_version.py
+
       - name: Run tests
         run: uv run --no-project python -m pytest tests
 
@@ -61,6 +64,9 @@ jobs:
           uv build
           uv pip install dist/*.whl pytest
 
+      - name: Inject version into client
+        run: uv run --no-project python scripts/inject_version.py
+
       - name: Run tests using installed package
         run: uv run --no-project pytest tests
 
@@ -83,6 +89,9 @@ jobs:
 
       - name: Sync dependencies
         run: uv sync
+
+      - name: Inject version into client
+        run: uv run --no-project python scripts/inject_version.py
 
       - name: Generate example HTML
         run: uv run python tests/example_use/generate_example_html.py

--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ cython_debug/
 
 # Client wheel artifact
 client/*.whl
+client/version.js

--- a/client/main.js
+++ b/client/main.js
@@ -1,4 +1,4 @@
-const VERSION = "0.1.27";
+import { VERSION } from "./version.js";
 
 export function initializeUI(root = document) {
   if (typeof $ === "undefined") {

--- a/kaiserlift/__init__.py
+++ b/kaiserlift/__init__.py
@@ -1,22 +1,37 @@
-from .viewers import (
-    get_closest_exercise,
-    plot_df,
-    print_oldest_exercise,
-    gen_html_viewer,
-)
+from importlib.metadata import PackageNotFoundError, version
 
-from .df_processers import (
-    calculate_1rm,
-    highest_weight_per_rep,
-    estimate_weight_from_1rm,
-    add_1rm_column,
-    df_next_pareto,
-    assert_frame_equal,
-    import_fitnotes_csv,
-    process_csv_files,
-)
+try:
+    __version__ = version("kaiserlift")
+except PackageNotFoundError:  # pragma: no cover - fallback for dev environments
+    from pathlib import Path
+    import tomllib
 
-from .pipeline import pipeline
+    _pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    with _pyproject.open("rb") as _f:
+        __version__ = tomllib.load(_f)["project"]["version"]
+
+try:
+    from .viewers import (
+        get_closest_exercise,
+        plot_df,
+        print_oldest_exercise,
+        gen_html_viewer,
+    )
+
+    from .df_processers import (
+        calculate_1rm,
+        highest_weight_per_rep,
+        estimate_weight_from_1rm,
+        add_1rm_column,
+        df_next_pareto,
+        assert_frame_equal,
+        import_fitnotes_csv,
+        process_csv_files,
+    )
+
+    from .pipeline import pipeline
+except ModuleNotFoundError:  # pragma: no cover - allow __version__ without deps
+    pass
 
 __all__ = [
     "calculate_1rm",

--- a/scripts/inject_version.py
+++ b/scripts/inject_version.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+from pathlib import Path
+
+from kaiserlift import __version__
+
+
+def main() -> None:
+    """Write the package version to ``client/version.js``."""
+    out = Path(__file__).resolve().parent.parent / "client" / "version.js"
+    out.write_text(f'export const VERSION = "{__version__}";\n', encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/example_use/generate_example_html.py
+++ b/tests/example_use/generate_example_html.py
@@ -16,8 +16,9 @@ def main() -> None:
     for name in ("example.html", "index.html"):
         (out_dir / name).write_text(html, encoding="utf-8")
 
-    client_js = here.parent.parent / "client" / "main.js"
-    shutil.copy(client_js, out_dir / "main.js")
+    client_dir = here.parent.parent / "client"
+    for name in ("main.js", "version.js"):
+        shutil.copy(client_dir / name, out_dir / name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- generate client/version.js from the package's __version__
- have client code import the generated version file
- run version injection in CI before tests and asset builds

## Testing
- `uvx pre-commit run --files kaiserlift/__init__.py scripts/inject_version.py client/main.js tests/example_use/generate_example_html.py .github/workflows/main.yml .github/workflows/build-client-wheel.yml .gitignore`
- `uv run --no-project pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689ea66d85748333a3e5ff21a44b01ca