### PR TITLE
docs: mention version injection for client build

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -4,5 +4,8 @@ This directory hosts the built wheel for static serving. The wheel is generated 
 
 ## Rebuild locally
 1. Install the build backend with `pip install build` or `uv`.
-2. Run `python -m build` (or `uv build`) from the repository root.
-3. Copy `dist/kaiserlift-<VERSION>-py3-none-any.whl` to this directory, renaming it to `kaiserlift.whl`.
+2. Run `python scripts/inject_version.py` to write the current package version to `client/version.js`. This keeps `main.js` aligned with the Python package.
+3. Run `python -m build` (or `uv build`) from the repository root.
+4. Copy `dist/kaiserlift-<VERSION>-py3-none-any.whl` to this directory, renaming it to `kaiserlift.whl`.
+
+CI executes `scripts/inject_version.py` before publishing artifacts, so builds always embed the correct version. Contributors should run the same script whenever the Python package version changes to keep `client/main.js` in sync with the wheel filename.


### PR DESCRIPTION
## Summary
- document running the version injection script before copying the built wheel
- note that CI runs the script so client/main.js matches the Python package version

## Testing
- `python -m pre_commit run --files client/README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f61246fa4833382e237bf7a544485