### PR TITLE
feat: add upload progress bar

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -104,6 +104,7 @@ await micropip.install('kaiserlift')
 
     const fileInput = doc.getElementById("csvFile");
     const uploadButton = doc.getElementById("uploadButton");
+    const progressBar = doc.getElementById("uploadProgress");
 
     uploadButton.addEventListener("click", async () => {
       const file = fileInput.files?.[0];
@@ -112,23 +113,33 @@ await micropip.install('kaiserlift')
         return;
       }
 
+      if (progressBar) {
+        progressBar.style.display = "block";
+        progressBar.value = 0;
+      }
+
       try {
         const text = await file.text();
+        if (progressBar) progressBar.value = 25;
         pyodide.globals.set("csv_text", text);
+        if (progressBar) progressBar.value = 50;
         const html = await pyodide.runPythonAsync(`
 import io
 from kaiserlift.pipeline import pipeline
 buffer = io.StringIO(csv_text)
 pipeline([buffer], embed_assets=False)
 `);
+        if (progressBar) progressBar.value = 90;
         result.innerHTML = "";
         result.innerHTML = html;
         initializeUI(result);
+        if (progressBar) progressBar.value = 100;
       } catch (err) {
         console.error(err);
         result.textContent = "Failed to process CSV: " + err;
       } finally {
         pyodide.globals.delete("csv_text");
+        if (progressBar) progressBar.style.display = "none";
       }
     });
   } catch (err) {

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -271,6 +271,7 @@ def gen_html_viewer(df, *, embed_assets: bool = True) -> str:
     upload_html = """
     <input type="file" id="csvFile">
     <button id="uploadButton">Upload</button>
+    <progress id="uploadProgress" value="0" max="100" style="display:none;"></progress>
     """
 
     scripts = """

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -30,6 +30,7 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert html.count('id="result"') == 1
     assert 'id="uploadButton"' in html
     assert 'id="csvFile"' in html
+    assert 'id="uploadProgress"' in html
 
 
 def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
@@ -45,3 +46,4 @@ def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
     assert 'id="uploadButton"' not in html
     assert 'id="csvFile"' not in html
     assert 'id="result"' not in html
+    assert 'id="uploadProgress"' not in html

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,6 +13,7 @@ def test_pipeline_generates_html() -> None:
     assert "<table" in html
     assert html.count('id="result"') == 1
     assert 'id="uploadButton"' in html
+    assert 'id="uploadProgress"' in html
 
 
 def test_pipeline_fragment_without_assets() -> None:
@@ -25,3 +26,4 @@ def test_pipeline_fragment_without_assets() -> None:
     assert 'id="uploadButton"' not in html
     assert 'id="csvFile"' not in html
     assert 'id="result"' not in html
+    assert 'id="uploadProgress"' not in html

--- a/tests/test_pyodide_client.py
+++ b/tests/test_pyodide_client.py
@@ -32,6 +32,7 @@ def test_pipeline_via_pyodide(tmp_path: Path) -> None:
                 addEventListener: (event, cb) => {{ elements.uploadButton._cb = cb; }},
                 click: async () => {{ await elements.uploadButton._cb(); }}
               }},
+              uploadProgress: {{ style: {{ display: 'none' }}, value: 0 }},
               result: {{ textContent: '', innerHTML: '<tr><td>Old Exercise</td></tr>' }}
             }};
             const doc = {{
@@ -69,6 +70,8 @@ def test_pipeline_via_pyodide(tmp_path: Path) -> None:
             console.log((elements.result.innerHTML.match(/id=\"uploadButton\"/g) || []).length === 1);
             console.log(elements.result.innerHTML.includes('Bicep Curl'));
             console.log(elements.result.innerHTML.includes('exercise-figure'));
+            console.log(elements.uploadProgress.value === 100);
+            console.log(elements.uploadProgress.style.display === 'none');
 
             elements.csvFile.files = [{{ text: async () => csv2 }}];
             await elements.uploadButton.click();
@@ -77,6 +80,8 @@ def test_pipeline_via_pyodide(tmp_path: Path) -> None:
             console.log(elements.result.innerHTML.includes('Tricep Pushdown'));
             console.log(!elements.result.innerHTML.includes('Bicep Curl'));
             console.log(elements.result.innerHTML.includes('exercise-figure'));
+            console.log(elements.uploadProgress.value === 100);
+            console.log(elements.uploadProgress.style.display === 'none');
             """
         )
     )
@@ -85,4 +90,4 @@ def test_pipeline_via_pyodide(tmp_path: Path) -> None:
         ["node", script.as_posix()], capture_output=True, text=True, check=True
     )
     lines = [line for line in result.stdout.splitlines() if line]
-    assert lines[-10:] == ["true"] * 10
+    assert lines[-14:] == ["true"] * 14


### PR DESCRIPTION
## Summary
- show a progress indicator while CSV uploads are processed
- test progress bar rendering and completion

## Testing
- `pre-commit run --files client/main.js kaiserlift/viewers.py tests/test_gen_html.py tests/test_pipeline.py tests/test_pyodide_client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f69893280833380480625174845d7