### PR TITLE
docs: clarify table fragment contents

### DIFF
--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -149,9 +149,9 @@ def print_oldest_exercise(
 def render_table_fragment(df) -> str:
     """Render the viewer fragment without external assets.
 
-    The returned HTML contains the dropdown, upload controls, table and all
-    figures but omits any ``<script>`` or ``<link>`` tags so that assets can be
-    injected separately.
+    The returned HTML contains only the dropdown, table, and figures while
+    omitting any ``<script>`` or ``<link>`` tags so that assets can be injected
+    separately.
     """
 
     df_records = highest_weight_per_rep(df)


### PR DESCRIPTION
## Summary
- clarify that `render_table_fragment` returns only dropdown, table, and figures

## Testing
- `pre-commit run --files kaiserlift/viewers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f6953e520833396170ebbdd237a6f