### PR TITLE
Wrap viewer HTML with head and body

### DIFF
--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -306,5 +306,6 @@ def gen_html_viewer(df, *, embed_assets: bool = True) -> str:
     <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
     <script type="module" src="main.js"></script>
     """
-
-    return js_and_css + upload_html + f'<div id="result">{fragment}</div>' + scripts
+    head_html = js_and_css + scripts
+    body_html = upload_html + f'<div id="result">{fragment}</div>'
+    return f"<html><head>{head_html}</head><body>{body_html}</body></html>"


### PR DESCRIPTION
## Summary
- Wrap HTML viewer output in `<html>`, `<head>`, and `<body>` tags
- Place stylesheet and script references inside `<head>`
- Keep upload controls and results inside `<body>`

## Testing
- `pre-commit run --files kaiserlift/viewers.py`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0e35c4ee883339c029707c9b1a474