### PR TITLE
Add UTF-8 meta tag to HTML viewer

### DIFF
--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -306,6 +306,7 @@ def gen_html_viewer(df, *, embed_assets: bool = True) -> str:
     <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
     <script type="module" src="main.js"></script>
     """
-    head_html = js_and_css + scripts
+    meta = '<meta charset="utf-8">'
+    head_html = meta + js_and_css + scripts
     body_html = upload_html + f'<div id="result">{fragment}</div>'
     return f"<html><head>{head_html}</head><body>{body_html}</body></html>"

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -47,3 +47,20 @@ def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
     assert 'id="csvFile"' not in html
     assert 'id="result"' not in html
     assert 'id="uploadProgress"' not in html
+
+
+def test_gen_html_viewer_renders_non_ascii(tmp_path: Path) -> None:
+    csv_file = (
+        Path(__file__).parent
+        / "example_use"
+        / "FitNotes_Export_2025_05_21_08_39_11.csv"
+    )
+    df = process_csv_files([str(csv_file)])
+    df.loc[len(df)] = df.iloc[0]
+    df.at[len(df) - 1, "Exercise"] = "Café del Mar"
+    html = gen_html_viewer(df)
+    out_file = tmp_path / "non_ascii.html"
+    out_file.write_text(html, encoding="utf-8")
+    contents = out_file.read_text(encoding="utf-8")
+    assert '<meta charset="utf-8">' in html
+    assert "Café del Mar" in contents


### PR DESCRIPTION
## Summary
- declare UTF-8 charset in generated viewer HTML
- test HTML generator with non-ASCII characters

## Testing
- `pre-commit run --files kaiserlift/viewers.py tests/test_gen_html.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0f0d484448333b3af3d307da5f82c