### PR TITLE
feat: add viewport meta tag

### DIFF
--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -224,6 +224,10 @@ def gen_html_viewer(df, *, embed_assets: bool = True) -> str:
     if not embed_assets:
         return fragment
 
+    viewport_meta = (
+        '<meta name="viewport" content="width=device-width, initial-scale=1">'
+    )
+
     js_and_css = """
     <!-- DataTables -->
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css"/>
@@ -306,6 +310,6 @@ def gen_html_viewer(df, *, embed_assets: bool = True) -> str:
     <script src="https://cdn.jsdelivr.net/pyodide/v0.24.1/full/pyodide.js"></script>
     <script type="module" src="main.js"></script>
     """
-    head_html = js_and_css + scripts
+    head_html = viewport_meta + js_and_css + scripts
     body_html = upload_html + f'<div id="result">{fragment}</div>'
     return f"<html><head>{head_html}</head><body>{body_html}</body></html>"

--- a/tests/test_gen_html.py
+++ b/tests/test_gen_html.py
@@ -31,6 +31,9 @@ def test_gen_html_viewer_creates_html(tmp_path: Path) -> None:
     assert 'id="uploadButton"' in html
     assert 'id="csvFile"' in html
     assert 'id="uploadProgress"' in html
+    assert (
+        '<meta name="viewport" content="width=device-width, initial-scale=1">' in html
+    )
 
 
 def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
@@ -47,3 +50,4 @@ def test_gen_html_viewer_without_scripts(tmp_path: Path) -> None:
     assert 'id="csvFile"' not in html
     assert 'id="result"' not in html
     assert 'id="uploadProgress"' not in html
+    assert '<meta name="viewport"' not in html


### PR DESCRIPTION
## Summary
- ensure viewer HTML is mobile-friendly with a viewport meta tag
- test coverage for viewport meta presence

## Testing
- `pre-commit run --files kaiserlift/viewers.py tests/test_gen_html.py`
- `PYTHONPATH=. pytest` *(fails: cannot import name 'calculate_1rm' from 'kaiserlift'; module 'kaiserlift' has no attribute 'pipeline')*
- `python - <<'PY'
from kaiserlift.viewers import gen_html_viewer
import pandas as pd
from playwright.sync_api import sync_playwright
columns = {'Date': ['2024-01-01','2024-01-02'],'Exercise':['Bench Press','Bench Press'],'Reps':[5,8],'Weight':[100,80],'Category':['Upper','Upper']}
df = pd.DataFrame(columns)
html = gen_html_viewer(df)
with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page(viewport={'width': 320, 'height': 640})
    page.set_content(html)
    width = page.evaluate('document.documentElement.clientWidth')
    print('clientWidth:', width)
    browser.close()
PY` *(fails: BrowserType.launch: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f0df28a8833394aba2c1faad8fb4