### PR TITLE
feat: smooth upload progress bar

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -113,26 +113,22 @@ await micropip.install('kaiserlift')
         return;
       }
 
+      let progressInterval;
       if (progressBar) {
         progressBar.style.display = "block";
         progressBar.value = 0;
+        progressInterval = setInterval(() => {
+          if (progressBar.value < 90) {
+            progressBar.value = Math.min(progressBar.value + 1, 90);
+          } else {
+            clearInterval(progressInterval);
+          }
+        }, 100);
       }
 
-      let progressInterval;
       try {
         const text = await file.text();
-        if (progressBar) progressBar.value = 25;
         pyodide.globals.set("csv_text", text);
-        if (progressBar) {
-          progressBar.value = 50;
-          progressInterval = setInterval(() => {
-            if (progressBar.value < 90) {
-              progressBar.value = Math.min(progressBar.value + 1, 90);
-            } else {
-              clearInterval(progressInterval);
-            }
-          }, 100);
-        }
         const html = await pyodide.runPythonAsync(`
 import io
 from kaiserlift.pipeline import pipeline

--- a/client/main.js
+++ b/client/main.js
@@ -116,7 +116,7 @@ await micropip.install('kaiserlift')
       let progressInterval;
       if (progressBar) {
         progressBar.style.display = "block";
-        progressBar.value = 0;
+        progressBar.value = 10;
         progressInterval = setInterval(() => {
           if (progressBar.value < 90) {
             progressBar.value = Math.min(progressBar.value + 1, 90);
@@ -128,18 +128,24 @@ await micropip.install('kaiserlift')
 
       try {
         const text = await file.text();
+        if (progressBar) progressBar.value = 25;
         pyodide.globals.set("csv_text", text);
+        if (progressBar) progressBar.value = 50;
         const html = await pyodide.runPythonAsync(`
-import io
-from kaiserlift.pipeline import pipeline
-buffer = io.StringIO(csv_text)
-pipeline([buffer], embed_assets=False)
-`);
-        if (progressInterval) clearInterval(progressInterval);
+          import io
+          from kaiserlift.pipeline import pipeline
+          buffer = io.StringIO(csv_text)
+          pipeline([buffer], embed_assets=False)
+        `);
+        if (progressBar) progressBar.value = 75;
         result.innerHTML = "";
         result.innerHTML = html;
         initializeUI(result);
-        if (progressBar) progressBar.value = 100;
+        if (progressBar) {
+          progressBar.value = 90;
+          if (progressInterval) clearInterval(progressInterval);
+          progressBar.value = 100;
+        }
       } catch (err) {
         console.error(err);
         result.textContent = "Failed to process CSV: " + err;


### PR DESCRIPTION
## Summary
- smooth client upload progress bar using gradual increments while processing

## Testing
- `python -m pre_commit run --files client/main.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a22c91078483338a5ea92b2603e93c