### PR TITLE
Cache Pyodide output in localStorage

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -68,14 +68,14 @@ async function fetchWheel(doc) {
 export async function init(loadPyodide, doc = document) {
   const result = doc.getElementById("result");
 
+  // Ensure the initial UI is usable even if Pyodide fails to load.
+  initializeUI(doc);
+
   const cachedHtml = localStorage.getItem("kaiserliftHtml");
   if (cachedHtml) {
     result.innerHTML = cachedHtml;
     initializeUI(result);
   }
-
-  // Ensure the initial UI is usable even if Pyodide fails to load.
-  initializeUI(doc);
 
   try {
     const loader =


### PR DESCRIPTION
## Summary
- Restore previous HTML from `localStorage` on init
- Cache CSV/HTML after uploads and add a clear data button
- Test localStorage interactions and cached content restoration

## Testing
- `pre-commit run --files client/main.js tests/test_pyodide_client.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3732781208333b6c25cd572bf77c5