### PR TITLE
Extend Pareto front to max rep

### DIFF
--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -69,8 +69,9 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
         max_1rm = max(one_rms)
 
         # Extend Pareto front horizontally to cover all target reps
+        # up to the furthest rep among data and targets
         last_weight = pareto_weights[-1]
-        pareto_reps.append(plot_max_rep)
+        pareto_reps.append(max_rep)
         pareto_weights.append(last_weight)
 
         # Generate dotted Epley decay line

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -54,7 +54,7 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
 
     min_rep = min(series.min() for series in rep_series)
     max_rep = max(series.max() for series in rep_series)
-    plot_max_rep = max_rep + max(1, 0.05 * max_rep)
+    plot_max_rep = max_rep + 1
 
     fig, ax = plt.subplots()
 

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -54,6 +54,7 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
 
     min_rep = min(series.min() for series in rep_series)
     max_rep = max(series.max() for series in rep_series)
+    plot_max_rep = max_rep + max(1, 0.05 * max_rep)
 
     fig, ax = plt.subplots()
 
@@ -62,17 +63,18 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
         pareto_reps, pareto_weights = zip(*sorted(pareto_points, key=lambda x: x[0]))
         pareto_reps = list(pareto_reps)
         pareto_weights = list(pareto_weights)
-        # Extend Pareto front horizontally to cover all target reps
-        last_weight = pareto_weights[-1]
-        pareto_reps.append(max_rep)
-        pareto_weights.append(last_weight)
 
         # Compute best 1RM from Pareto front
         one_rms = [calculate_1rm(w, r) for w, r in zip(pareto_weights, pareto_reps)]
         max_1rm = max(one_rms)
 
+        # Extend Pareto front horizontally to cover all target reps
+        last_weight = pareto_weights[-1]
+        pareto_reps.append(plot_max_rep)
+        pareto_weights.append(last_weight)
+
         # Generate dotted Epley decay line
-        x_vals = np.linspace(min_rep, max_rep, 10)
+        x_vals = np.linspace(min_rep, plot_max_rep, 10)
         y_vals = [estimate_weight_from_1rm(max_1rm, r) for r in x_vals]
         ax.plot(x_vals, y_vals, "k--", label="Max Achieved 1RM", alpha=0.7)
 
@@ -89,7 +91,7 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
         min_1rm = min(one_rms)
 
         # Generate dotted Epley decay line
-        x_vals = np.linspace(min_rep, max_rep, 10)
+        x_vals = np.linspace(min_rep, plot_max_rep, 10)
         y_vals = [estimate_weight_from_1rm(min_1rm, r) for r in x_vals]
         ax.plot(x_vals, y_vals, "g-.", label="Min Target 1RM", alpha=0.7)
 
@@ -106,7 +108,7 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
 
     ax.set_title(f"Weight vs. Reps for {closest_match}")
     ax.set_xlabel("Reps")
-    ax.set_xlim(left=0, right=max_rep)
+    ax.set_xlim(left=0, right=plot_max_rep)
     ax.set_ylabel("Weight")
     ax.legend()
 

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -69,10 +69,11 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
         max_1rm = max(one_rms)
 
         # Extend Pareto front horizontally to cover all target reps
-        # up to the furthest rep among data and targets
+        # up to the furthest rep among data and targets while keeping the
+        # extra point out of the plotted markers
         last_weight = pareto_weights[-1]
-        pareto_reps.append(max_rep)
-        pareto_weights.append(last_weight)
+        pareto_reps_ext = pareto_reps + [max_rep]
+        pareto_weights_ext = pareto_weights + [last_weight]
 
         # Generate dotted Epley decay line
         x_vals = np.linspace(min_rep, plot_max_rep, 10)
@@ -80,7 +81,17 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
         ax.plot(x_vals, y_vals, "k--", label="Max Achieved 1RM", alpha=0.7)
 
         ax.step(
-            pareto_reps, pareto_weights, color="red", marker="o", label="Pareto Front"
+            pareto_reps_ext,
+            pareto_weights_ext,
+            color="red",
+            label="Pareto Front",
+        )
+        ax.scatter(
+            pareto_reps,
+            pareto_weights,
+            color="red",
+            marker="o",
+            label="_nolegend_",
         )
 
     if df_targets is not None:

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -45,18 +45,27 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
         df_pareto = df_pareto[df_pareto["Exercise"] == closest_match]
     if df_targets is not None:
         df_targets = df_targets[df_targets["Exercise"] == closest_match]
+
+    rep_series = [df["Reps"]]
+    if df_pareto is not None and not df_pareto.empty:
+        rep_series.append(df_pareto["Reps"])
     if df_targets is not None and not df_targets.empty:
-        min_rep = df_targets["Reps"].min()
-        max_rep = df_targets["Reps"].max()
-    else:
-        min_rep = df["Reps"].min()
-        max_rep = df["Reps"].max()
+        rep_series.append(df_targets["Reps"])
+
+    min_rep = min(series.min() for series in rep_series)
+    max_rep = max(series.max() for series in rep_series)
 
     fig, ax = plt.subplots()
 
     if df_pareto is not None:
         pareto_points = list(zip(df_pareto["Reps"], df_pareto["Weight"]))
         pareto_reps, pareto_weights = zip(*sorted(pareto_points, key=lambda x: x[0]))
+        pareto_reps = list(pareto_reps)
+        pareto_weights = list(pareto_weights)
+        # Extend Pareto front horizontally to cover all target reps
+        last_weight = pareto_weights[-1]
+        pareto_reps.append(max_rep)
+        pareto_weights.append(last_weight)
 
         # Compute best 1RM from Pareto front
         one_rms = [calculate_1rm(w, r) for w, r in zip(pareto_weights, pareto_reps)]

--- a/kaiserlift/viewers.py
+++ b/kaiserlift/viewers.py
@@ -68,21 +68,14 @@ def plot_df(df, df_pareto=None, df_targets=None, Exercise: str = None):
         one_rms = [calculate_1rm(w, r) for w, r in zip(pareto_weights, pareto_reps)]
         max_1rm = max(one_rms)
 
-        # Extend Pareto front horizontally to cover all target reps
-        # up to the furthest rep among data and targets while keeping the
-        # extra point out of the plotted markers
-        last_weight = pareto_weights[-1]
-        pareto_reps_ext = pareto_reps + [max_rep]
-        pareto_weights_ext = pareto_weights + [last_weight]
-
         # Generate dotted Epley decay line
         x_vals = np.linspace(min_rep, plot_max_rep, 10)
         y_vals = [estimate_weight_from_1rm(max_1rm, r) for r in x_vals]
         ax.plot(x_vals, y_vals, "k--", label="Max Achieved 1RM", alpha=0.7)
 
         ax.step(
-            pareto_reps_ext,
-            pareto_weights_ext,
+            pareto_reps,
+            pareto_weights,
             color="red",
             label="Pareto Front",
         )


### PR DESCRIPTION
## Summary
- ensure `plot_df` includes max reps across all data sources
- extend Pareto front with `(max_rep, last_weight)` so step covers targets

## Testing
- `pre-commit run --files kaiserlift/viewers.py`
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4951e1c7083338d1bd29cedaa1b93