### PR TITLE
Add distance-dependent Riegel exponent for ultra-marathon predictions

### DIFF
--- a/tests/test_running_viewers.py
+++ b/tests/test_running_viewers.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from kaiserlift.running_viewers import plot_running_df
+from kaiserlift.running_processers import riegel_pace_exponent
 
 
 def _get_trace(fig, name: str):
@@ -56,7 +57,7 @@ def test_running_curves_anchor_to_points():
     best_target_idx = 0
     sample = np.linspace(0.5, 10.0, 50).tolist()
     for i, (t_dist, t_dur) in enumerate(zip(df_targets["Distance"], target_durations)):
-        times = [t_dur * (d / t_dist) ** 1.06 for d in sample]
+        times = [t_dur * (d / t_dist) ** (1 + riegel_pace_exponent(d)) for d in sample]
         mean_t = float(np.mean(times))
         if mean_t > best_score:
             best_score = mean_t


### PR DESCRIPTION
## Summary
Extends the classic Riegel running performance prediction formula with a distance-dependent exponent that increases for ultra-marathon distances. This captures the non-linear fatigue accumulation observed in empirical race data, where pace drops off faster than the standard fixed exponent of 0.06 predicts.

## Key Changes
- **New function `riegel_pace_exponent()`**: Implements piecewise linear interpolation between empirically-derived breakpoints:
  - 0.06 for distances up to half marathon (13.1 mi)
  - Increases to 0.07 at marathon (26.2 mi)
  - Reaches 0.11 at 50 miles and 0.14 at 100 miles
  - Caps at 0.14 beyond 100 miles

- **Updated `estimate_pace_at_distance()`**: Now uses the variable exponent instead of the fixed 0.06 value, providing more accurate predictions for ultra-marathon distances

- **Updated visualization curves**: Both `plot_running_df()` and `curve_score_time()` now use the distance-dependent exponent when generating Riegel prediction curves

- **Enhanced documentation**: Added detailed comments explaining the physiological rationale (glycogen depletion, muscle damage, sleep deprivation) for the steeper exponent at ultra distances

- **Comprehensive test coverage**: Added `test_riegel_pace_exponent()` to verify monotonic growth and boundary conditions, plus additional test case for 50-mile predictions

## Implementation Details
The exponent interpolation is monotonically non-decreasing across all distances, ensuring consistent predictions. The formula remains `pace2 = pace1 * (d2/d1)^b` where `b` is now distance-dependent, with the time exponent being `1 + b`.

https://claude.ai/code/session_016VBnxUp3zDS3uCUR7FhQ6b